### PR TITLE
Remove deprecated pipe from metaprogramming_utils.hpp

### DIFF
--- a/include/metaprogramming_utils.hpp
+++ b/include/metaprogramming_utils.hpp
@@ -114,27 +114,6 @@ struct has_subscript {
 template <typename T>
 inline constexpr bool has_subscript_v = has_subscript<T>::value;
 
-//
-// checks if a type is any instance of SYCL pipe
-//
-namespace detail {
-
-template<typename T>
-struct is_sycl_pipe_impl : std::false_type {};
-
-template<typename Id, typename T, std::size_t N>
-struct is_sycl_pipe_impl<sycl::ext::intel::pipe<Id, T, N>> : std::true_type {};
-
-}  // namespace detail
-
-template <typename T>
-struct is_sycl_pipe {
-  static constexpr bool value = detail::is_sycl_pipe_impl<T>{};
-};
-
-template <typename T>
-inline constexpr bool is_sycl_pipe_v = is_sycl_pipe<T>::value;
-
 } // namespace gpu_tools
 
 #endif  /* __METAPROGRAMMING_UTILS_HPP__ */


### PR DESCRIPTION
Closes #3

Removes the `is_sycl_pipe` / `is_sycl_pipe_v` type trait since these relied on `sycl::ext::intel::pipe`, which is no longer available after intel/llvm dropped FPGA support in the latest release, causing build failures.

Changes:
- Removed detail::is_sycl_pipe_impl partial specialization
- Removed is_sycl_pipe struct and is_sycl_pipe_v variable template
- Removed the detail namespace block (no longer needed)